### PR TITLE
Correção na validação de data(n_date)

### DIFF
--- a/xlsxwriter.class.php
+++ b/xlsxwriter.class.php
@@ -362,7 +362,10 @@ class XLSXWriter
 		$this->finalizeSheet($sheet_name);
 	}
 
-	protected function writeCell(XLSXWriter_BuffererWriter &$file, $row_number, $column_number, $value, $num_format_type, $cell_style_idx)
+    /**
+     * @throws Exception
+     */
+    protected function writeCell(XLSXWriter_BuffererWriter &$file, $row_number, $column_number, $value, $num_format_type, $cell_style_idx)
 	{
 		$cell_name = self::xlsCell($row_number, $column_number);
 
@@ -374,7 +377,13 @@ class XLSXWriter
             if (strtotime($value) > 0){
                 $file->write('<c r="'.$cell_name.'" s="'.$cell_style_idx.'" t="n"><v>'.intval(self::convert_date_time($value)).'</v></c>');
             }else{
-                $file->write('<c r="'.$cell_name.'" s="'.$cell_style_idx.'" t="n"><v></v></c>');
+                $DateTime = new DateTimeImmutable($value);
+                $dateFormatted = $DateTime->format('d/m/Y');
+                if (is_string($dateFormatted) && strlen($dateFormatted) >= 10){
+                    $file->write('<c r="'.$cell_name.'" s="'.$cell_style_idx.'" t="n"><v>'.intval(self::convert_date_time($value)).'</v></c>');
+                } else {
+                    $file->write('<c r="'.$cell_name.'" s="'.$cell_style_idx.'" t="n"><v></v></c>');
+                }
             }
 		} elseif ($num_format_type=='n_datetime') {
             if (strtotime($value) > 0){


### PR DESCRIPTION
Olá,

quando uma data(Y-m-d) é menor que 1970-01-01, a função **strtotime**  retorna um valor negativo, assim implicando na validação e inserindo vazio na planilha xls. Isso acontece por causa do padrão [UNIX](https://pt.wikipedia.org/wiki/Era_Unix#:~:text=O%20nome%20se%20deve%20ao,ser%20chamada%20de%20era%20POSIX.).

Por isso, inseri uma validação no _else_ para formatar a data e comparar se retorna uma data válida, se sim, insere a data com a formatação padrão da classe. Assim, não alterando as demais datas. 

Problema pode ser notado [aqui](https://stackoverflow.com/questions/3469474/why-strotime-returns-negative-value-in-php).